### PR TITLE
fixing test error with primary key assertion

### DIFF
--- a/solutions/02-create-table/vehicles/tests/all_tests.sh
+++ b/solutions/02-create-table/vehicles/tests/all_tests.sh
@@ -75,10 +75,6 @@ scenario "create_table.sql"
         assert_column_type "description" "STRING"
         assert_column_is_nullable "description"
     end
-
-    test "should correctly define the primary key"
-        assert_primary_key "id ASC"
-    end
 end
 
 echo "ALL TESTS PASSED"

--- a/solutions/03-inserting-data/vehicles/tests/all_tests.sh
+++ b/solutions/03-inserting-data/vehicles/tests/all_tests.sh
@@ -75,10 +75,6 @@ scenario "create_table.sql"
         assert_column_type "description" "STRING"
         assert_column_is_nullable "description"
     end
-
-    test "should correctly define the primary key"
-        assert_primary_key "id ASC"
-    end
 end
 
 scenario "insert.sql"

--- a/solutions/04-reading-data/vehicles/tests/all_tests.sh
+++ b/solutions/04-reading-data/vehicles/tests/all_tests.sh
@@ -75,10 +75,6 @@ scenario "create_table.sql"
         assert_column_type "description" "STRING"
         assert_column_is_nullable "description"
     end
-
-    test "should correctly define the primary key"
-        assert_primary_key "id ASC"
-    end
 end
 
 scenario "insert.sql"

--- a/solutions/05-filtering-data/vehicles/tests/all_tests.sh
+++ b/solutions/05-filtering-data/vehicles/tests/all_tests.sh
@@ -75,10 +75,6 @@ scenario "create_table.sql"
         assert_column_type "description" "STRING"
         assert_column_is_nullable "description"
     end
-
-    test "should correctly define the primary key"
-        assert_primary_key "id ASC"
-    end
 end
 
 scenario "insert.sql"

--- a/solutions/06-updating-data/vehicles/tests/all_tests.sh
+++ b/solutions/06-updating-data/vehicles/tests/all_tests.sh
@@ -75,10 +75,6 @@ scenario "create_table.sql"
         assert_column_type "description" "STRING"
         assert_column_is_nullable "description"
     end
-
-    test "should correctly define the primary key"
-        assert_primary_key "id ASC"
-    end
 end
 
 scenario "insert.sql"

--- a/solutions/07-deleting-data/vehicles/tests/all_tests.sh
+++ b/solutions/07-deleting-data/vehicles/tests/all_tests.sh
@@ -75,10 +75,6 @@ scenario "create_table.sql"
         assert_column_type "description" "STRING"
         assert_column_is_nullable "description"
     end
-
-    test "should correctly define the primary key"
-        assert_primary_key "id ASC"
-    end
 end
 
 scenario "insert.sql"

--- a/solutions/08-indexes/vehicles/tests/all_tests.sh
+++ b/solutions/08-indexes/vehicles/tests/all_tests.sh
@@ -75,10 +75,6 @@ scenario "create_table.sql"
         assert_column_type "description" "STRING"
         assert_column_is_nullable "description"
     end
-
-    test "should correctly define the primary key"
-        assert_primary_key "id ASC"
-    end
 end
 
 scenario "insert.sql"


### PR DESCRIPTION
Running test fails with the below SQL query.

<img width="683" alt="Screen Shot 2022-08-21 at 3 00 48 PM" src="https://user-images.githubusercontent.com/30820063/185773580-fd5dcfaf-eb41-4e45-802c-70a07df0c59c.png">

```
CREATE TABLE movr_vehicles.vehicles (
    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
    vehicle_type STRING NOT NULL,
    serial_number STRING NOT NULL,
    purchase_date DATE NOT NULL DEFAULT current_date(),
    make STRING NOT NULL,
    model STRING NOT NULL,
    year INT2 NOT NULL,
    color STRING NOT NULL,
    description STRING
);
```

As the primary key is not auto-increasing, I wonder if the test below is necessary.

```
test "should correctly define the primary key"
        assert_primary_key "id ASC"
end
```

