### PR TITLE
Make primary key regex more flexible to match table without other indexes.

### DIFF
--- a/exercises/vehicles/tests/sql_testkit.sh
+++ b/exercises/vehicles/tests/sql_testkit.sh
@@ -155,7 +155,7 @@ load_table_definition() {
     load_from_query "SHOW COLUMNS FROM $COCKROACH_TABLE;"
 
     local CREATE_TABLE=$(cockroach sql --url $COCKROACH_URL --execute "SHOW CREATE TABLE $COCKROACH_TABLE;")
-    local REGEX=".* PRIMARY KEY \((.*)\),.*"
+    local REGEX=".* PRIMARY KEY \(([^\)]*)\)"
 
     if [[ $CREATE_TABLE =~ $REGEX ]]
     then

--- a/solutions/00-initial-state/vehicles/tests/sql_testkit.sh
+++ b/solutions/00-initial-state/vehicles/tests/sql_testkit.sh
@@ -155,7 +155,7 @@ load_table_definition() {
     load_from_query "SHOW COLUMNS FROM $COCKROACH_TABLE;"
 
     local CREATE_TABLE=$(cockroach sql --url $COCKROACH_URL --execute "SHOW CREATE TABLE $COCKROACH_TABLE;")
-    local REGEX=".* PRIMARY KEY \((.*)\),.*"
+    local REGEX=".* PRIMARY KEY \(([^\)]*)\)"
 
     if [[ $CREATE_TABLE =~ $REGEX ]]
     then

--- a/solutions/01-create-database/vehicles/tests/sql_testkit.sh
+++ b/solutions/01-create-database/vehicles/tests/sql_testkit.sh
@@ -155,7 +155,7 @@ load_table_definition() {
     load_from_query "SHOW COLUMNS FROM $COCKROACH_TABLE;"
 
     local CREATE_TABLE=$(cockroach sql --url $COCKROACH_URL --execute "SHOW CREATE TABLE $COCKROACH_TABLE;")
-    local REGEX=".* PRIMARY KEY \((.*)\),.*"
+    local REGEX=".* PRIMARY KEY \(([^\)]*)\)"
 
     if [[ $CREATE_TABLE =~ $REGEX ]]
     then

--- a/solutions/02-create-table/vehicles/tests/sql_testkit.sh
+++ b/solutions/02-create-table/vehicles/tests/sql_testkit.sh
@@ -155,7 +155,7 @@ load_table_definition() {
     load_from_query "SHOW COLUMNS FROM $COCKROACH_TABLE;"
 
     local CREATE_TABLE=$(cockroach sql --url $COCKROACH_URL --execute "SHOW CREATE TABLE $COCKROACH_TABLE;")
-    local REGEX=".* PRIMARY KEY \((.*)\),.*"
+    local REGEX=".* PRIMARY KEY \(([^\)]*)\)"
 
     if [[ $CREATE_TABLE =~ $REGEX ]]
     then

--- a/solutions/03-inserting-data/vehicles/tests/sql_testkit.sh
+++ b/solutions/03-inserting-data/vehicles/tests/sql_testkit.sh
@@ -155,7 +155,7 @@ load_table_definition() {
     load_from_query "SHOW COLUMNS FROM $COCKROACH_TABLE;"
 
     local CREATE_TABLE=$(cockroach sql --url $COCKROACH_URL --execute "SHOW CREATE TABLE $COCKROACH_TABLE;")
-    local REGEX=".* PRIMARY KEY \((.*)\),.*"
+    local REGEX=".* PRIMARY KEY \(([^\)]*)\)"
 
     if [[ $CREATE_TABLE =~ $REGEX ]]
     then

--- a/solutions/04-reading-data/vehicles/tests/sql_testkit.sh
+++ b/solutions/04-reading-data/vehicles/tests/sql_testkit.sh
@@ -155,7 +155,7 @@ load_table_definition() {
     load_from_query "SHOW COLUMNS FROM $COCKROACH_TABLE;"
 
     local CREATE_TABLE=$(cockroach sql --url $COCKROACH_URL --execute "SHOW CREATE TABLE $COCKROACH_TABLE;")
-    local REGEX=".* PRIMARY KEY \((.*)\),.*"
+    local REGEX=".* PRIMARY KEY \(([^\)]*)\)"
 
     if [[ $CREATE_TABLE =~ $REGEX ]]
     then

--- a/solutions/05-filtering-data/vehicles/tests/sql_testkit.sh
+++ b/solutions/05-filtering-data/vehicles/tests/sql_testkit.sh
@@ -155,7 +155,7 @@ load_table_definition() {
     load_from_query "SHOW COLUMNS FROM $COCKROACH_TABLE;"
 
     local CREATE_TABLE=$(cockroach sql --url $COCKROACH_URL --execute "SHOW CREATE TABLE $COCKROACH_TABLE;")
-    local REGEX=".* PRIMARY KEY \((.*)\),.*"
+    local REGEX=".* PRIMARY KEY \(([^\)]*)\)"
 
     if [[ $CREATE_TABLE =~ $REGEX ]]
     then

--- a/solutions/06-updating-data/vehicles/tests/sql_testkit.sh
+++ b/solutions/06-updating-data/vehicles/tests/sql_testkit.sh
@@ -155,7 +155,7 @@ load_table_definition() {
     load_from_query "SHOW COLUMNS FROM $COCKROACH_TABLE;"
 
     local CREATE_TABLE=$(cockroach sql --url $COCKROACH_URL --execute "SHOW CREATE TABLE $COCKROACH_TABLE;")
-    local REGEX=".* PRIMARY KEY \((.*)\),.*"
+    local REGEX=".* PRIMARY KEY \(([^\)]*)\)"
 
     if [[ $CREATE_TABLE =~ $REGEX ]]
     then

--- a/solutions/07-deleting-data/vehicles/tests/sql_testkit.sh
+++ b/solutions/07-deleting-data/vehicles/tests/sql_testkit.sh
@@ -155,7 +155,7 @@ load_table_definition() {
     load_from_query "SHOW COLUMNS FROM $COCKROACH_TABLE;"
 
     local CREATE_TABLE=$(cockroach sql --url $COCKROACH_URL --execute "SHOW CREATE TABLE $COCKROACH_TABLE;")
-    local REGEX=".* PRIMARY KEY \((.*)\),.*"
+    local REGEX=".* PRIMARY KEY \(([^\)]*)\)"
 
     if [[ $CREATE_TABLE =~ $REGEX ]]
     then

--- a/solutions/08-indexes/vehicles/tests/sql_testkit.sh
+++ b/solutions/08-indexes/vehicles/tests/sql_testkit.sh
@@ -155,7 +155,7 @@ load_table_definition() {
     load_from_query "SHOW COLUMNS FROM $COCKROACH_TABLE;"
 
     local CREATE_TABLE=$(cockroach sql --url $COCKROACH_URL --execute "SHOW CREATE TABLE $COCKROACH_TABLE;")
-    local REGEX=".* PRIMARY KEY \((.*)\),.*"
+    local REGEX=".* PRIMARY KEY \(([^\)]*)\)"
 
     if [[ $CREATE_TABLE =~ $REGEX ]]
     then


### PR DESCRIPTION
The current regex only matches tables that have other lines _after_ the primary key constraint in the table definition, e.g.

```
CREATE TABLE public.vehicles (
  id UUID NOT NULL DEFAULT gen_random_uuid(), 
  ...
  CONSTRAINT vehicles_pkey PRIMARY KEY (id ASC),
  INDEX some_other_index ...
)"
```

This is because the regex matches against a `,`. In a table like for exercise 2 where there's no other indexes, the regex fails, and you get this error, even with the solution:

```
TEST: should correctly define the primary key
./tests/sql_testkit.sh: line 443: TABLE_PRIMARY_KEY: unbound variable
```

You can repro this by doing:

```
$ ./load_solution.sh 02
$ ./test.sh
```

The fix is to make the regex more flexible, and not require a `,`. Unfortunately, greedy matching means that

```
local REGEX=".* PRIMARY KEY \((.*)\).*"
```

doesn't work, it'll [match against the trailing closing paren](https://regex101.com/r/kQ7kh3/1) in the table definition. It's also not possible to do [non-greedy regexes in Bash with `=~`](https://unix.stackexchange.com/a/128373/173844).

So instead I did a trick where I match everything up to the next closing `)` using `[^\)]*`. [Demo](https://regex101.com/r/HeObuj/1).