### PR TITLE
Fixing an issue with booleans on CockroachDB v22.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install CockroachDB v22.2
-        run: curl https://binaries.cockroachdb.com/cockroach-v22.2.2.linux-amd64.tgz | tar -xz && sudo cp -i cockroach-v21.2.6.linux-amd64/cockroach /usr/local/bin/
+        run: curl https://binaries.cockroachdb.com/cockroach-v22.2.2.linux-amd64.tgz | tar -xz && sudo cp -i cockroach-v22.2.2.linux-amd64/cockroach /usr/local/bin/
       - name: Run the tests for all exercises
         run: ./build.sh verify

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install CockroachDB
-        run: curl https://binaries.cockroachdb.com/cockroach-v21.2.6.linux-amd64.tgz | tar -xz && sudo cp -i cockroach-v21.2.6.linux-amd64/cockroach /usr/local/bin/
+      - name: Install CockroachDB v22.2
+        run: curl https://binaries.cockroachdb.com/cockroach-v22.2.2.linux-amd64.tgz | tar -xz && sudo cp -i cockroach-v21.2.6.linux-amd64/cockroach /usr/local/bin/
       - name: Run the tests for all exercises
         run: ./build.sh verify

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ IFS=$'\n\t'
 
 EXERCISES_FOLDER="exercises"
 SOLUTIONS_FOLDER="solutions"
-SOLUTIONS=($(ls $SOLUTIONS_FOLDER | grep '^[0-9]'))
+SOLUTIONS=($(ls --color=never $SOLUTIONS_FOLDER | grep '^[0-9]'))
 SUBFOLDERS=("vehicles")
 COMMAND=${1:-"help"}
 


### PR DESCRIPTION
- Problem caused because shell now uses `t` and `f` rather than `true` and `false` (change was made to align with postgreSQL shell)
- Added a function to convert `t` to `true` and `f` to `false` and anything else to itself.
- Modified an index test that didn't store the non_unique result and check it, but just checked an entire line.